### PR TITLE
[BE] build: ddl 쿼리의 컬럼명 create_date -> created_date 로 정정

### DIFF
--- a/be/src/main/resources/sql/ddl-h2.sql
+++ b/be/src/main/resources/sql/ddl-h2.sql
@@ -3,21 +3,21 @@ CREATE TABLE `card` (
     `columns_id` bigint,
     `title` varchar(255),
     `content` varchar(500),
-    `create_date` timestamp,
+    `created_date` timestamp,
     `modified_date` timestamp
 );
 
 CREATE TABLE `columns` (
     `id` bigint PRIMARY KEY AUTO_INCREMENT,
     `name` varchar(255),
-    `create_date` timestamp,
+    `created_date` timestamp,
     `modified_date` timestamp
 );
 
 CREATE TABLE `users` (
     `id` bigint PRIMARY KEY AUTO_INCREMENT,
     `name` varchar(255),
-    `create_date` timestamp,
+    `created_date` timestamp,
     `modified_date` timestamp
 );
 
@@ -27,7 +27,7 @@ CREATE TABLE `history` (
    `card_id` bigint,
    `columns_id` bigint,
    `action` char,
-   `create_date` timestamp,
+   `created_date` timestamp,
    `modified_date` timestamp
 );
 


### PR DESCRIPTION
수정일 컬럼들은 `modified_date` 인데, 생성일 컬럼은 `create_date` 로 되어있습니다..
명칭 통일을 위해 `create_date` -> `created_date` 로 컬럼명을 정정해야할 것 같습니다..!
