### PR TITLE
[BE] feat: 칼럼 조회 기능 추가

### DIFF
--- a/be/src/main/java/com/ijava/todolist/column/controller/ColumnController.java
+++ b/be/src/main/java/com/ijava/todolist/column/controller/ColumnController.java
@@ -1,0 +1,37 @@
+package com.ijava.todolist.column.controller;
+
+import com.ijava.todolist.card.service.CardService;
+import com.ijava.todolist.column.controller.dto.ColumnResponse;
+import com.ijava.todolist.column.domain.Column;
+import com.ijava.todolist.column.service.ColumnService;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ColumnController {
+
+    private final ColumnService columnService;
+    private final CardService cardService;
+
+    @Autowired
+    public ColumnController(ColumnService columnService, CardService cardService) {
+        this.columnService = columnService;
+        this.cardService = cardService;
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    @GetMapping("/columns")
+    public List<ColumnResponse> columnList() {
+        List<Column> columnList = columnService.findColumns();
+        return columnList.stream()
+            .map(column -> ColumnResponse.from(column, cardService))
+            .collect(Collectors.toList());
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/column/controller/ColumnController.java
+++ b/be/src/main/java/com/ijava/todolist/column/controller/ColumnController.java
@@ -6,27 +6,20 @@ import com.ijava.todolist.column.domain.Column;
 import com.ijava.todolist.column.service.ColumnService;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RestController
 public class ColumnController {
 
     private final ColumnService columnService;
     private final CardService cardService;
 
-    @Autowired
-    public ColumnController(ColumnService columnService, CardService cardService) {
-        this.columnService = columnService;
-        this.cardService = cardService;
-    }
-
     @ResponseStatus(HttpStatus.OK)
-    @ResponseBody
     @GetMapping("/columns")
     public List<ColumnResponse> columnList() {
         List<Column> columnList = columnService.findColumns();

--- a/be/src/main/java/com/ijava/todolist/column/controller/dto/ColumnResponse.java
+++ b/be/src/main/java/com/ijava/todolist/column/controller/dto/ColumnResponse.java
@@ -1,0 +1,27 @@
+package com.ijava.todolist.column.controller.dto;
+
+
+import com.ijava.todolist.card.service.CardService;
+import com.ijava.todolist.column.domain.Column;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ColumnResponse {
+
+    private Long columnId;
+    private String name;
+    private int cardCount;
+
+    public static ColumnResponse from(Column column, CardService cardService) {
+        Long id = column.getId();
+        int cardCount = cardService.getCountOfCardsOnColumns(id);
+
+        ColumnResponse columnResponse = new ColumnResponse();
+        columnResponse.setColumnId(id);
+        columnResponse.setName(column.getName());
+        columnResponse.setCardCount(cardCount);
+        return columnResponse;
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/column/domain/Column.java
+++ b/be/src/main/java/com/ijava/todolist/column/domain/Column.java
@@ -1,0 +1,23 @@
+package com.ijava.todolist.column.domain;
+
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@EqualsAndHashCode
+@ToString
+public class Column {
+
+    private final Long id;
+    private final String name;
+    private final LocalDateTime createdDate;
+    private final LocalDateTime modifiedDate;
+}

--- a/be/src/main/java/com/ijava/todolist/column/repository/ColumnRepository.java
+++ b/be/src/main/java/com/ijava/todolist/column/repository/ColumnRepository.java
@@ -1,0 +1,10 @@
+package com.ijava.todolist.column.repository;
+
+import com.ijava.todolist.column.domain.Column;
+import java.util.List;
+import java.util.Optional;
+
+public interface ColumnRepository {
+
+    Optional<List<Column>> findAll();
+}

--- a/be/src/main/java/com/ijava/todolist/column/repository/JDBCColumnRepository.java
+++ b/be/src/main/java/com/ijava/todolist/column/repository/JDBCColumnRepository.java
@@ -1,0 +1,35 @@
+package com.ijava.todolist.column.repository;
+
+import com.ijava.todolist.column.domain.Column;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JDBCColumnRepository implements ColumnRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public JDBCColumnRepository(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    @Override
+    public Optional<List<Column>> findAll() {
+        String findAllSql = "SELECT id,name,created_date,modified_date FROM columns";
+        List<Column> columnList = jdbcTemplate.query(findAllSql, columnRowMapper());
+        return columnList.isEmpty() ? Optional.empty() : Optional.of(columnList);
+    }
+
+    private RowMapper<Column> columnRowMapper() {
+        return (rs, rowNum) -> Column.builder()
+            .id(rs.getLong("id"))
+            .name(rs.getString("name"))
+            .createdDate(rs.getTimestamp("created_date").toLocalDateTime())
+            .modifiedDate(rs.getTimestamp("modified_date").toLocalDateTime())
+            .build();
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/column/service/ColumnService.java
+++ b/be/src/main/java/com/ijava/todolist/column/service/ColumnService.java
@@ -1,0 +1,22 @@
+package com.ijava.todolist.column.service;
+
+import com.ijava.todolist.column.domain.Column;
+import com.ijava.todolist.column.repository.ColumnRepository;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ColumnService {
+
+    private final ColumnRepository columnRepository;
+
+    public ColumnService(ColumnRepository columnRepository) {
+        this.columnRepository = columnRepository;
+    }
+
+    public List<Column> findColumns() {
+        return columnRepository.findAll()
+            .orElseGet(Collections::emptyList);
+    }
+}

--- a/be/src/main/resources/sql/test/column-dml-h2.sql
+++ b/be/src/main/resources/sql/test/column-dml-h2.sql
@@ -1,0 +1,3 @@
+INSERT INTO columns (id, name, created_date, modified_date) VALUES (1, '해야할 일', '2022-04-05 19:11:11', '2022-04-05 19:11:11');
+INSERT INTO columns (id, name, created_date, modified_date) VALUES (2, '하고 있는 일', '2022-04-05 19:12:11', '2022-04-05 19:12:11');
+INSERT INTO columns (id, name, created_date, modified_date) VALUES (3, '완료한 일', '2022-04-05 19:13:11', '2022-04-05 19:13:11');

--- a/be/src/test/java/com/ijava/todolist/column/controller/ColumnControllerTest.java
+++ b/be/src/test/java/com/ijava/todolist/column/controller/ColumnControllerTest.java
@@ -1,0 +1,124 @@
+package com.ijava.todolist.column.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ijava.todolist.card.service.CardService;
+import com.ijava.todolist.column.domain.Column;
+import com.ijava.todolist.column.service.ColumnService;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(ColumnController.class)
+@DisplayName("ColumnController 테스트")
+class ColumnControllerTest {
+
+    private static final int EXIST_CARD_COUNT = 5;
+    private static final int EMPTY_CARD_COUNT = 0;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ColumnService columnService;
+
+    @MockBean
+    private CardService cardService;
+
+    private static List<Column> columnList;
+
+    @BeforeAll
+    static void setup() {
+        Column column1 = Column.builder()
+            .id(1L)
+            .name("해야할 일")
+            .createdDate(
+                LocalDateTime.parse("2022-04-05T19:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            .modifiedDate(
+                LocalDateTime.parse("2022-04-05T19:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            .build();
+        Column column2 = Column.builder()
+            .id(2L)
+            .name("하고 있는 일")
+            .createdDate(
+                LocalDateTime.parse("2022-04-05T19:12:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            .modifiedDate(
+                LocalDateTime.parse("2022-04-05T19:12:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            .build();
+        columnList = Arrays.asList(column1, column2);
+    }
+
+    @Nested
+    @DisplayName("GET /columns 요청이 들어왔을때,")
+    class GETColumnsTest {
+
+        @Nested
+        @DisplayName("기존 컬럼들이 존재하면")
+        class ColumnExistTest {
+
+            @Test
+            @DisplayName("각 컬럼들의 아이디, 이름, 해당 컬럼에 속하는 카드 개수를 JSON 형식으로 반환한다.")
+            void columnListTest() throws Exception {
+                // given
+                given(cardService.getCountOfCardsOnColumns(any()))
+                    .willReturn(EXIST_CARD_COUNT);
+                given(columnService.findColumns())
+                    .willReturn(columnList);
+
+                // when
+                ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/columns"));
+
+                // then
+                result.andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0]").exists())
+                    .andExpect(jsonPath("$[1]").exists())
+
+                    .andExpect(jsonPath("$[0].columnId", is(columnList.get(0).getId().intValue())))
+                    .andExpect(jsonPath("$[0].name", is(columnList.get(0).getName())))
+                    .andExpect(jsonPath("$[0].cardCount", is(EXIST_CARD_COUNT)))
+
+                    .andExpect(jsonPath("$[1].columnId", is(columnList.get(1).getId().intValue())))
+                    .andExpect(jsonPath("$[1].name", is(columnList.get(1).getName())))
+                    .andExpect(jsonPath("$[1].cardCount", is(EXIST_CARD_COUNT)));
+            }
+        }
+
+        @Nested
+        @DisplayName("기존 컬럼들이 존재하지 않으면")
+        class ColumnEmptyTest {
+
+            @Test
+            @DisplayName("빈 리스트를 JSON 형식으로 반환한다.")
+            void columnListTest() throws Exception {
+                // given
+                given(cardService.getCountOfCardsOnColumns(any()))
+                    .willReturn(EMPTY_CARD_COUNT);
+                given(columnService.findColumns())
+                    .willReturn(Collections.emptyList());
+
+                // when
+                ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/columns"));
+
+                // then
+                result.andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isEmpty());
+            }
+        }
+    }
+}

--- a/be/src/test/java/com/ijava/todolist/column/repository/ColumnRepositoryTest.java
+++ b/be/src/test/java/com/ijava/todolist/column/repository/ColumnRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.ijava.todolist.column.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ijava.todolist.column.domain.Column;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.test.context.jdbc.Sql;
+
+@JdbcTest
+@DisplayName("ColumnRepository 테스트")
+class ColumnRepositoryTest {
+
+    private static final int TEST_COLUMN_COUNT = 3;
+
+    ColumnRepository columnRepository;
+
+    @Autowired
+    public ColumnRepositoryTest(DataSource dataSource) {
+        this.columnRepository = new JDBCColumnRepository(dataSource);
+    }
+
+    @Nested
+    @DisplayName("모든 컬럼들을 가져올 때,")
+    class findAllTest {
+
+        @Test
+        @DisplayName("기존 컬럼들이 없다면 빈 리스트를 반환한다.")
+        void emptyColumn() {
+            // when
+            Optional<List<Column>> result = columnRepository.findAll();
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @Sql("classpath:sql/test/column-dml-h2.sql")
+        @DisplayName("기존 컬럼들이 존재한다면 해당 칼럼들의 리스트를 반환한다.")
+        void existColumn() {
+            // given
+            // 3개의 테스트 데이터 추가
+
+            // when
+            Optional<List<Column>> result = columnRepository.findAll();
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).hasSize(TEST_COLUMN_COUNT);
+        }
+    }
+}

--- a/be/src/test/java/com/ijava/todolist/column/service/ColumnServiceTest.java
+++ b/be/src/test/java/com/ijava/todolist/column/service/ColumnServiceTest.java
@@ -1,0 +1,90 @@
+package com.ijava.todolist.column.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.ijava.todolist.column.domain.Column;
+import com.ijava.todolist.column.repository.ColumnRepository;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ColumnService 테스트")
+class ColumnServiceTest {
+
+    private static final int TEST_COLUMN_COUNT = 2;
+
+    @Mock
+    private ColumnRepository columnRepository;
+
+    @InjectMocks
+    private ColumnService columnService;
+
+    private static List<Column> columnList;
+
+    @BeforeAll
+    static void setup() {
+        Column column1 = Column.builder()
+            .id(1L)
+            .name("해야할 일")
+            .createdDate(
+                LocalDateTime.parse("2022-04-05T19:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            .modifiedDate(
+                LocalDateTime.parse("2022-04-05T19:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            .build();
+        Column column2 = Column.builder()
+            .id(2L)
+            .name("하고 있는 일")
+            .createdDate(
+                LocalDateTime.parse("2022-04-05T19:12:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            .modifiedDate(
+                LocalDateTime.parse("2022-04-05T19:12:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            .build();
+        columnList = Arrays.asList(column1, column2);
+    }
+
+    @Nested
+    @DisplayName("모든 컬럼들을 조회할 때,")
+    class findColumnsTest {
+
+        @Test
+        @DisplayName("기존 컬럼들이 없다면 Optional.empty()를 반환한다.")
+        void emptyColumn() {
+            // given
+            given(columnRepository.findAll())
+                .willReturn(Optional.empty());
+
+            // when
+            List<Column> result = columnService.findColumns();
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("기존 컬럼들이 존재한다면 해당 칼럼들의 리스트를 반환한다.")
+        void existColumn() {
+            // given
+            given(columnRepository.findAll())
+                .willReturn(Optional.of(columnList));
+
+            // when
+            List<Column> result = columnService.findColumns();
+
+            // then
+            assertThat(result).isNotEmpty()
+                .hasSize(TEST_COLUMN_COUNT);
+        }
+    }
+}


### PR DESCRIPTION
- 칼럼 목록 조회 API 추가
- 칼럼 조회시, 해당 컬럼의 카드 수를 포함하여 반환하는 기능 추가

### 📕 Issue Number

close #5

### 📙 작업 내역

- [x] 칼럼 조회 기능 추가

### 📘 작업 유형

- [x] 신규 기능 추가

### 📝 PR 특이 사항

- 테스트에 필요한 데이터를 SQL 파일로 작성하여, 테스트 수행시 실행되도록 하였습니다.

<br/><br/>
