### PR TITLE
[BE] feat: 활동기록 기능 구현

### DIFF
--- a/be/src/main/java/com/ijava/todolist/history/Action.java
+++ b/be/src/main/java/com/ijava/todolist/history/Action.java
@@ -1,0 +1,8 @@
+package com.ijava.todolist.history;
+
+public enum Action {
+    ADD,
+    REMOVE,
+    UPDATE,
+    MOVE;
+}

--- a/be/src/main/java/com/ijava/todolist/history/controller/HistoryController.java
+++ b/be/src/main/java/com/ijava/todolist/history/controller/HistoryController.java
@@ -1,0 +1,26 @@
+package com.ijava.todolist.history.controller;
+
+import com.ijava.todolist.history.controller.dto.HistoryResponse;
+import com.ijava.todolist.history.domain.History;
+import com.ijava.todolist.history.service.HistoryService;
+import com.ijava.todolist.history.util.HistoryResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class HistoryController {
+
+    private final HistoryService historyService;
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/history")
+    public List<HistoryResponse> historyList() {
+        List<History> historyList = historyService.findHistories();
+        return HistoryResolver.resolveHistoryList(historyList);
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/history/controller/dto/HistoryResponse.java
+++ b/be/src/main/java/com/ijava/todolist/history/controller/dto/HistoryResponse.java
@@ -1,0 +1,30 @@
+package com.ijava.todolist.history.controller.dto;
+
+import com.ijava.todolist.history.domain.History;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class HistoryResponse {
+
+    private String action;
+    private Long cardId;
+    private Long oldColumn;
+    private Long newColumn;
+    private LocalDateTime modifiedDate;
+
+    public HistoryResponse(History history) {
+        this.action = history.getAction().name();
+        this.cardId = history.getCardId();
+        this.oldColumn = history.getColumnsId();
+        this.newColumn = history.getColumnsId();
+        this.modifiedDate = history.getModifiedDate();
+    }
+
+    public HistoryResponse(History history, Long oldColumn) {
+        this(history);
+        this.oldColumn = oldColumn;
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/history/domain/History.java
+++ b/be/src/main/java/com/ijava/todolist/history/domain/History.java
@@ -1,0 +1,39 @@
+package com.ijava.todolist.history.domain;
+
+import com.ijava.todolist.history.Action;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class History {
+
+    private Long id;
+    private final Long userId;
+    private final Long cardId;
+    private final Long columnsId;
+    private final Action action;
+    private final LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+
+    public History(@NonNull Long userId, @NonNull Long cardId, @NonNull Long columnsId,
+        @NonNull Action action, @NonNull LocalDateTime createdDate) {
+        this.userId = userId;
+        this.cardId = cardId;
+        this.columnsId = columnsId;
+        this.action = action;
+        this.createdDate = createdDate;
+        this.modifiedDate = createdDate;
+    }
+
+    public History(Long id, @NonNull Long userId, @NonNull Long cardId, @NonNull Long columnsId,
+        @NonNull Action action, @NonNull LocalDateTime createdDate,
+        @NonNull LocalDateTime modifiedDate) {
+        this(userId, cardId, columnsId, action, createdDate);
+        this.id = id;
+        this.modifiedDate = modifiedDate;
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/history/exception/HistoryNotSavedException.java
+++ b/be/src/main/java/com/ijava/todolist/history/exception/HistoryNotSavedException.java
@@ -1,0 +1,15 @@
+package com.ijava.todolist.history.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class HistoryNotSavedException extends HistoryRuntimeException {
+
+    public HistoryNotSavedException() {
+        super("활동기록을 저장하는데에 실패하였습니다.");
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/history/exception/HistoryRuntimeException.java
+++ b/be/src/main/java/com/ijava/todolist/history/exception/HistoryRuntimeException.java
@@ -1,0 +1,10 @@
+package com.ijava.todolist.history.exception;
+
+import com.ijava.todolist.exception.GlobalRuntimeException;
+
+public abstract class HistoryRuntimeException extends GlobalRuntimeException {
+
+    public HistoryRuntimeException(String message) {
+        super(message);
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/history/repository/HistoryRepository.java
+++ b/be/src/main/java/com/ijava/todolist/history/repository/HistoryRepository.java
@@ -1,0 +1,12 @@
+package com.ijava.todolist.history.repository;
+
+import com.ijava.todolist.history.domain.History;
+import java.util.List;
+import java.util.Optional;
+
+public interface HistoryRepository {
+
+    void save(History history);
+
+    Optional<List<History>> findAll();
+}

--- a/be/src/main/java/com/ijava/todolist/history/repository/JdbcHistoryRepository.java
+++ b/be/src/main/java/com/ijava/todolist/history/repository/JdbcHistoryRepository.java
@@ -1,0 +1,67 @@
+package com.ijava.todolist.history.repository;
+
+import com.ijava.todolist.history.Action;
+import com.ijava.todolist.history.domain.History;
+import com.ijava.todolist.history.exception.HistoryNotSavedException;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+public class JdbcHistoryRepository implements HistoryRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final SimpleJdbcInsert simpleJdbcInsert;
+
+    public JdbcHistoryRepository(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        this.simpleJdbcInsert = new SimpleJdbcInsert(jdbcTemplate)
+            .withTableName("history");
+    }
+
+    @Override
+    public void save(History history) {
+        try {
+            SqlParameterSource sqlParameterSource = new MapSqlParameterSource()
+                .addValue("user_id", history.getUserId())
+                .addValue("card_id", history.getCardId())
+                .addValue("columns_id", history.getColumnsId())
+                .addValue("action", history.getAction().name())
+                .addValue("created_date", history.getCreatedDate())
+                .addValue("modified_date", history.getModifiedDate());
+
+            simpleJdbcInsert.execute(sqlParameterSource);
+            log.debug(simpleJdbcInsert.getInsertString(), sqlParameterSource);
+        } catch (Exception e) {
+            throw new HistoryNotSavedException();
+        }
+    }
+
+    @Override
+    public Optional<List<History>> findAll() {
+        String findAllSql = "SELECT id,user_id,card_id,columns_id,action,created_date,modified_date FROM history";
+        List<History> historyList = jdbcTemplate.query(findAllSql, historyRowMapper());
+        log.debug(findAllSql, historyList);
+        return historyList.isEmpty() ? Optional.empty() : Optional.of(historyList);
+    }
+
+    private RowMapper<History> historyRowMapper() {
+        return (rs, rowNum) -> new History(
+            rs.getLong("id"),
+            rs.getLong("user_id"),
+            rs.getLong("card_id"),
+            rs.getLong("columns_id"),
+            Action.valueOf(rs.getString("action")),
+            rs.getTimestamp("created_date").toLocalDateTime(),
+            rs.getTimestamp("modified_date").toLocalDateTime()
+        );
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/history/service/HistoryService.java
+++ b/be/src/main/java/com/ijava/todolist/history/service/HistoryService.java
@@ -1,0 +1,39 @@
+package com.ijava.todolist.history.service;
+
+import com.ijava.todolist.history.Action;
+import com.ijava.todolist.history.domain.History;
+import com.ijava.todolist.history.exception.HistoryNotSavedException;
+import com.ijava.todolist.history.repository.HistoryRepository;
+import com.ijava.todolist.user.service.UserService;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+
+    private final HistoryRepository historyRepository;
+    private final UserService userService;
+
+    public void store(Long cardId, Long columnsId, Action action, LocalDateTime createdDate) {
+        try {
+            Long userId = getDefaultUserId();
+            History history = new History(userId, cardId, columnsId, action, createdDate);
+            historyRepository.save(history);
+        } catch (NullPointerException e) {
+            throw new HistoryNotSavedException();
+        }
+    }
+
+    public List<History> findHistories() {
+        return historyRepository.findAll()
+            .orElseGet(Collections::emptyList);
+    }
+
+    private Long getDefaultUserId() {
+        return userService.findDefaultUserId();
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/history/util/HistoryResolver.java
+++ b/be/src/main/java/com/ijava/todolist/history/util/HistoryResolver.java
@@ -1,0 +1,44 @@
+package com.ijava.todolist.history.util;
+
+import com.ijava.todolist.history.Action;
+import com.ijava.todolist.history.controller.dto.HistoryResponse;
+import com.ijava.todolist.history.domain.History;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+public class HistoryResolver {
+
+    public static List<HistoryResponse> resolveHistoryList(List<History> historyList) {
+
+        // 각 카드의 이전 컬럼 위치를 저장하기 위한 HashMap
+        // MOVE 행동의 경우, 이전 컬럼 위치가 필요하여 생성
+        // <K> - cardId
+        // <V> - recentColumnId
+        HashMap<Long, Long> historyHashMap = new HashMap<>();
+        List<HistoryResponse> historyResponseList = new ArrayList<>();
+
+        for (History history : historyList) {
+            HistoryResponse historyResponse = makeHistoryResponse(history, historyHashMap);
+            historyResponseList.add(historyResponse);
+        }
+        Collections.reverse(historyResponseList);
+        return historyResponseList;
+    }
+
+
+    private static HistoryResponse makeHistoryResponse(History history,
+        HashMap<Long, Long> historyHashMap) {
+        Action action = history.getAction();
+        Long cardId = history.getCardId();
+        Long oldColumId = historyHashMap.get(cardId);
+        Long newColumnId = history.getColumnsId();
+
+        historyHashMap.put(cardId, newColumnId);
+        if (action == Action.MOVE) {
+            return new HistoryResponse(history, oldColumId);
+        }
+        return new HistoryResponse(history);
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/user/domain/User.java
+++ b/be/src/main/java/com/ijava/todolist/user/domain/User.java
@@ -1,0 +1,17 @@
+package com.ijava.todolist.user.domain;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor
+@ToString
+public class User {
+
+    private Long id;
+    private final String name;
+    private final LocalDateTime createdDate;
+    private final LocalDateTime modifiedDate;
+}

--- a/be/src/main/java/com/ijava/todolist/user/exception/UserNotFoundException.java
+++ b/be/src/main/java/com/ijava/todolist/user/exception/UserNotFoundException.java
@@ -1,0 +1,15 @@
+package com.ijava.todolist.user.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UserNotFoundException extends UserRuntimeException {
+
+    public UserNotFoundException() {
+        super("사용자를 찾을 수 없습니다.");
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/user/exception/UserRuntimeException.java
+++ b/be/src/main/java/com/ijava/todolist/user/exception/UserRuntimeException.java
@@ -1,0 +1,10 @@
+package com.ijava.todolist.user.exception;
+
+import com.ijava.todolist.exception.GlobalRuntimeException;
+
+public abstract class UserRuntimeException extends GlobalRuntimeException {
+
+    public UserRuntimeException(String message) {
+        super(message);
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/user/repository/JdbcUserRepository.java
+++ b/be/src/main/java/com/ijava/todolist/user/repository/JdbcUserRepository.java
@@ -1,0 +1,45 @@
+package com.ijava.todolist.user.repository;
+
+import com.ijava.todolist.user.domain.User;
+import java.util.Optional;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+public class JdbcUserRepository implements UserRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public JdbcUserRepository(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        try {
+            String findByIdSql = "SELECT id,name,created_date,modified_date FROM users WHERE id = ?";
+
+            User user = jdbcTemplate.queryForObject(findByIdSql, userRowMapper(), id);
+
+            log.debug(findByIdSql, user);
+
+            return Optional.ofNullable(user);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    private RowMapper<User> userRowMapper() {
+        return (rs, rowNum) -> new User(
+            rs.getLong("id"),
+            rs.getString("name"),
+            rs.getTimestamp("created_date").toLocalDateTime(),
+            rs.getTimestamp("modified_date").toLocalDateTime()
+        );
+    }
+}

--- a/be/src/main/java/com/ijava/todolist/user/repository/UserRepository.java
+++ b/be/src/main/java/com/ijava/todolist/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.ijava.todolist.user.repository;
+
+import com.ijava.todolist.user.domain.User;
+import java.util.Optional;
+
+public interface UserRepository {
+
+    Optional<User> findById(Long id);
+}

--- a/be/src/main/java/com/ijava/todolist/user/service/UserService.java
+++ b/be/src/main/java/com/ijava/todolist/user/service/UserService.java
@@ -1,0 +1,26 @@
+package com.ijava.todolist.user.service;
+
+import com.ijava.todolist.user.domain.User;
+import com.ijava.todolist.user.exception.UserNotFoundException;
+import com.ijava.todolist.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private static final Long DEFAULT_USER_ID = 1L;
+
+    private final UserRepository userRepository;
+
+    private User findUserById(Long id) {
+        return userRepository.findById(id)
+            .orElseThrow(UserNotFoundException::new);
+    }
+
+    public Long findDefaultUserId() {
+        User defaultUser = findUserById(DEFAULT_USER_ID);
+        return defaultUser.getId();
+    }
+}

--- a/be/src/main/resources/sql/ddl-h2.sql
+++ b/be/src/main/resources/sql/ddl-h2.sql
@@ -26,7 +26,7 @@ CREATE TABLE `history` (
    `user_id` bigint,
    `card_id` bigint,
    `columns_id` bigint,
-   `action` char,
+   `action` char(6),
    `created_date` timestamp,
    `modified_date` timestamp
 );

--- a/be/src/main/resources/sql/test/history-dml-h2.sql
+++ b/be/src/main/resources/sql/test/history-dml-h2.sql
@@ -1,0 +1,4 @@
+INSERT INTO history (user_id, card_id, columns_id, action, created_date, modified_date) VALUES (1, 1, 1, 'ADD', '2022-04-05 19:11:11', '2022-04-05 19:11:11');
+INSERT INTO history (user_id, card_id, columns_id, action, created_date, modified_date) VALUES (1, 2, 2, 'REMOVE', '2022-04-05 19:12:11', '2022-04-05 19:12:11');
+INSERT INTO history (user_id, card_id, columns_id, action, created_date, modified_date) VALUES (1, 1, 1, 'UPDATE', '2022-04-05 19:13:11', '2022-04-05 19:13:11');
+INSERT INTO history (user_id, card_id, columns_id, action, created_date, modified_date) VALUES (1, 1, 3, 'MOVE', '2022-04-05 19:14:11', '2022-04-05 19:14:11');

--- a/be/src/main/resources/sql/test/user-dml-h2.sql
+++ b/be/src/main/resources/sql/test/user-dml-h2.sql
@@ -1,0 +1,1 @@
+INSERT INTO users (id, name, created_date, modified_date) VALUES (1, 'iJava', '2022-04-05 19:11:11', '2022-04-05 19:11:11');

--- a/be/src/test/java/com/ijava/todolist/history/controller/HistoryControllerTest.java
+++ b/be/src/test/java/com/ijava/todolist/history/controller/HistoryControllerTest.java
@@ -1,0 +1,144 @@
+package com.ijava.todolist.history.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ijava.todolist.history.Action;
+import com.ijava.todolist.history.domain.History;
+import com.ijava.todolist.history.service.HistoryService;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(HistoryController.class)
+@DisplayName("HistoryController 테스트")
+class HistoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private HistoryService historyService;
+
+    private static List<History> historyList;
+
+    @BeforeAll
+    static void setup() {
+        History history1 = new History(
+            1L,
+            1L,
+            2L,
+            Action.ADD,
+            LocalDateTime.parse("2022-04-05T19:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        );
+        History history2 = new History(
+            1L,
+            1L,
+            2L,
+            Action.MOVE,
+            LocalDateTime.parse("2022-04-05T20:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        );
+        History history3 = new History(
+            1L,
+            1L,
+            2L,
+            Action.UPDATE,
+            LocalDateTime.parse("2022-04-05T21:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        );
+        History history4 = new History(
+            1L,
+            1L,
+            2L,
+            Action.REMOVE,
+            LocalDateTime.parse("2022-04-05T22:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        );
+        historyList = Arrays.asList(history1, history2, history3, history4);
+    }
+
+    @Nested
+    @DisplayName("GET /history 요청이 들어왔을때,")
+    class GetHistoryTest {
+
+        @Nested
+        @DisplayName("기존 활동기록들이 존재하면")
+        class HistoryExistTest {
+
+            @Test
+            @DisplayName("각 행동의 이니셜, 카드 아이디, 이전 컬럼 아이디, 현재 컬럼아이디, 수정날짜 정보를 JSON 형식으로 반환한다.")
+            void historyList() throws Exception {
+                DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+                // given
+                given(historyService.findHistories())
+                    .willReturn(historyList);
+
+                // when
+                ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/history"));
+
+                // then
+                result.andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0]").exists())
+                    .andExpect(jsonPath("$[1]").exists())
+                    .andExpect(jsonPath("$[2]").exists())
+                    .andExpect(jsonPath("$[3]").exists())
+
+                    .andExpect(jsonPath("$[0].action", is(historyList.get(3).getAction().name())))
+                    .andExpect(jsonPath("$[0].cardId", is(historyList.get(3).getCardId().intValue())))
+                    .andExpect(jsonPath("$[0].oldColumn", is(historyList.get(3).getColumnsId().intValue())))
+                    .andExpect(jsonPath("$[0].newColumn", is(historyList.get(3).getColumnsId().intValue())))
+                    .andExpect(jsonPath("$[0].modifiedDate", is(historyList.get(3).getModifiedDate().format(dateTimeFormat))))
+
+                    .andExpect(jsonPath("$[1].action", is(historyList.get(2).getAction().name())))
+                    .andExpect(jsonPath("$[1].cardId", is(historyList.get(2).getCardId().intValue())))
+                    .andExpect(jsonPath("$[1].oldColumn", is(historyList.get(2).getColumnsId().intValue())))
+                    .andExpect(jsonPath("$[1].newColumn", is(historyList.get(2).getColumnsId().intValue())))
+                    .andExpect(jsonPath("$[1].modifiedDate", is(historyList.get(2).getModifiedDate().format(dateTimeFormat))))
+
+                    .andExpect(jsonPath("$[2].action", is(historyList.get(1).getAction().name())))
+                    .andExpect(jsonPath("$[2].cardId", is(historyList.get(1).getCardId().intValue())))
+                    .andExpect(jsonPath("$[2].oldColumn", is(historyList.get(0).getColumnsId().intValue())))
+                    .andExpect(jsonPath("$[2].newColumn", is(historyList.get(1).getColumnsId().intValue())))
+                    .andExpect(jsonPath("$[2].modifiedDate", is(historyList.get(1).getModifiedDate().format(dateTimeFormat))))
+
+                    .andExpect(jsonPath("$[3].action", is(historyList.get(0).getAction().name())))
+                    .andExpect(jsonPath("$[3].cardId", is(historyList.get(0).getCardId().intValue())))
+                    .andExpect(jsonPath("$[3].oldColumn", is(historyList.get(0).getColumnsId().intValue())))
+                    .andExpect(jsonPath("$[3].newColumn", is(historyList.get(0).getColumnsId().intValue())))
+                    .andExpect(jsonPath("$[3].modifiedDate", is(historyList.get(0).getModifiedDate().format(dateTimeFormat))));
+            }
+        }
+
+        @Nested
+        @DisplayName("기존 활동기록들이 존재하면")
+        class HistoryNotExistTest {
+
+            @Test
+            @DisplayName("빈 리스트를 JSON 형식으로 반환한다.")
+            void columnListTest() throws Exception {
+                // given
+                given(historyService.findHistories())
+                    .willReturn(Collections.emptyList());
+
+                // when
+                ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/history"));
+
+                // then
+                result.andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isEmpty());
+            }
+        }
+    }
+}

--- a/be/src/test/java/com/ijava/todolist/history/repository/HistoryRepositoryTest.java
+++ b/be/src/test/java/com/ijava/todolist/history/repository/HistoryRepositoryTest.java
@@ -1,0 +1,102 @@
+package com.ijava.todolist.history.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+
+import com.ijava.todolist.history.Action;
+import com.ijava.todolist.history.domain.History;
+import com.ijava.todolist.history.exception.HistoryNotSavedException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.test.context.jdbc.Sql;
+
+@JdbcTest
+@DisplayName("HistoryRepository 테스트")
+class HistoryRepositoryTest {
+
+    private static final int TEST_HISTORY_COUNT = 4;
+
+    HistoryRepository historyRepository;
+
+    @Autowired
+    public HistoryRepositoryTest(DataSource dataSource) {
+        this.historyRepository = new JdbcHistoryRepository(dataSource);
+    }
+
+
+    @Nested
+    @DisplayName("모든 활동기록들을 가져올 때,")
+    class findAllTest {
+
+        @Test
+        @DisplayName("기존 활동기록이 없다면 Optional.empty()를 반환한다.")
+        void emptyHistory() {
+            // when
+            Optional<List<History>> result = historyRepository.findAll();
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @Sql("classpath:sql/test/history-dml-h2.sql")
+        @DisplayName("기존 활동기록들이 존재한다면 해당 기록들의 리스트를 반환한다.")
+        void existHistory() {
+            // given
+            // 4개의 테스트 데이터 추가
+
+            // when
+            Optional<List<History>> result = historyRepository.findAll();
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).hasSize(TEST_HISTORY_COUNT);
+        }
+    }
+
+    @Nested
+    @DisplayName("활동기록을 저장할 때,")
+    class saveTest {
+
+        @Test
+        @DisplayName("활동기록이 null 이라면 HistoryNotSaved 예외를 반환한다.")
+        void nullHistory() {
+            // given
+            History nullHistory = null;
+
+            // when
+            Throwable thrown = catchThrowable(() -> historyRepository.save(nullHistory));
+
+            // then
+            assertThat(thrown).isInstanceOf(HistoryNotSavedException.class)
+                .hasMessageContaining("활동기록을 저장하는데에 실패하였습니다.");
+        }
+
+        @Test
+        @DisplayName("정상적인 활동기록이라면 아무 예외도 반환하지 않는다.")
+        void properHistory() {
+            // given
+            History properHistory = new History(
+                1L,
+                1L,
+                2L,
+                Action.ADD,
+                LocalDateTime.parse("2022-04-05T19:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            );
+
+            // when
+            Throwable thrown = catchThrowable(() -> historyRepository.save(properHistory));
+
+            // then
+            assertThat(thrown).doesNotThrowAnyException();
+        }
+    }
+}

--- a/be/src/test/java/com/ijava/todolist/history/service/HistoryServiceTest.java
+++ b/be/src/test/java/com/ijava/todolist/history/service/HistoryServiceTest.java
@@ -1,0 +1,141 @@
+package com.ijava.todolist.history.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+
+import com.ijava.todolist.history.Action;
+import com.ijava.todolist.history.domain.History;
+import com.ijava.todolist.history.exception.HistoryNotSavedException;
+import com.ijava.todolist.history.repository.HistoryRepository;
+import com.ijava.todolist.user.service.UserService;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HistoryService 테스트")
+class HistoryServiceTest {
+
+    private static final int TEST_HISTORY_COUNT = 2;
+    private static final Long DEFAULT_USER_ID = 1L;
+
+    @Mock
+    private HistoryRepository historyRepository;
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private HistoryService historyService;
+
+    private static List<History> historyList;
+
+    @BeforeAll
+    static void setup() {
+        History history1 = new History(
+            1L,
+            1L,
+            2L,
+            Action.ADD,
+            LocalDateTime.parse("2022-04-05T19:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        );
+        History history2 = new History(
+            1L,
+            1L,
+            3L,
+            Action.MOVE,
+            LocalDateTime.parse("2022-04-05T20:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        );
+        historyList = Arrays.asList(history1, history2);
+    }
+
+    @Nested
+    @DisplayName("모든 활동기록들을 조회할 때,")
+    class findHistoriesTest {
+
+        @Test
+        @DisplayName("기존 기록이 없다면 빈 리스트를 반환한다.")
+        void emptyHistory() {
+            // given
+            given(historyRepository.findAll())
+                .willReturn(Optional.empty());
+
+            // when
+            List<History> result = historyService.findHistories();
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("기존 기록들이 존재한다면 해당 기록들의 리스트를 반환한다.")
+        void existHistory() {
+            // given
+            given(historyRepository.findAll())
+                .willReturn(Optional.of(historyList));
+
+            // when
+            List<History> result = historyService.findHistories();
+
+            // then
+            assertThat(result).isNotEmpty()
+                .hasSize(TEST_HISTORY_COUNT);
+        }
+    }
+
+    @Nested
+    @DisplayName("활동기록을 저장할 때,")
+    class saveHistoryTest {
+
+        @Test
+        @DisplayName("null 값인 인자가 있다면 HistoryNotSaved 예외를 반환한다.")
+        void nullArgument() {
+            // when
+            Throwable thrown = catchThrowable(() -> historyService.store(
+                1L,
+                3L,
+                null,
+                LocalDateTime.parse("2022-04-05T20:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            );
+
+            // then
+            assertThat(thrown).isInstanceOf(HistoryNotSavedException.class)
+                .hasMessageContaining("활동기록을 저장하는데에 실패하였습니다.");
+        }
+
+        @Test
+        @DisplayName("인자를 정상적으로 넘겨준다면 아무 예외도 발생하지 않는다.")
+        void properArgument() {
+            // given
+            doNothing()
+                .when(historyRepository)
+                .save(any());
+            given(userService.findDefaultUserId())
+                .willReturn(DEFAULT_USER_ID);
+
+            // when
+            Throwable thrown = catchThrowable(() -> historyService.store(
+                1L,
+                3L,
+                Action.ADD,
+                LocalDateTime.parse("2022-04-05T20:11:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            );
+
+            // then
+            assertThat(thrown).doesNotThrowAnyException();
+        }
+    }
+
+}

--- a/be/src/test/java/com/ijava/todolist/history/util/HistoryResolverTest.java
+++ b/be/src/test/java/com/ijava/todolist/history/util/HistoryResolverTest.java
@@ -1,0 +1,62 @@
+package com.ijava.todolist.history.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ijava.todolist.history.Action;
+import com.ijava.todolist.history.controller.dto.HistoryResponse;
+import com.ijava.todolist.history.domain.History;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class HistoryResolverTest {
+
+    @Nested
+    @DisplayName("카드 1을 칼럼1에 ADD 하고")
+    class addFirst {
+
+        @Nested
+        @DisplayName("칼럼3으로 MOVE 하면")
+        class moveSecond {
+
+            @Test
+            @DisplayName("해당 기록들을 최신순으로 확인 할 수 있다.")
+            void properHistory() {
+                // given
+                History firstHistory = getHistory(1L, 1L, 1L, Action.ADD, 1);
+                History secondHistory = getHistory(1L, 1L, 3L, Action.MOVE, 2);
+
+                // when
+                List<HistoryResponse> result = HistoryResolver.resolveHistoryList(
+                    Arrays.asList(firstHistory, secondHistory));
+
+                // then
+                assertThat(result.get(0).getCardId()).isEqualTo(1L);
+                assertThat(result.get(0).getOldColumn()).isEqualTo(1L);
+                assertThat(result.get(0).getNewColumn()).isEqualTo(3L);
+                assertThat(result.get(0).getAction()).isEqualTo(Action.MOVE.name());
+
+                assertThat(result.get(1).getCardId()).isEqualTo(1L);
+                assertThat(result.get(1).getOldColumn()).isEqualTo(1L);
+                assertThat(result.get(1).getNewColumn()).isEqualTo(1L);
+                assertThat(result.get(1).getAction()).isEqualTo(Action.ADD.name());
+            }
+        }
+    }
+
+    private static History getHistory(Long userId, Long cardId, Long ColumnId, Action action,
+        int priority) {
+        return new History(
+            userId,
+            cardId,
+            ColumnId,
+            action,
+            LocalDateTime.parse("2022-04-05T20:11:" + String.format("%02d", priority),
+                DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        );
+    }
+}

--- a/be/src/test/java/com/ijava/todolist/user/repository/UserRepositoryTest.java
+++ b/be/src/test/java/com/ijava/todolist/user/repository/UserRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.ijava.todolist.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ijava.todolist.user.domain.User;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.test.context.jdbc.Sql;
+
+@JdbcTest
+@DisplayName("UserRepository 테스트")
+class UserRepositoryTest {
+
+    private static final Long DEFAULT_USER_ID = 1L;
+
+    UserRepository userRepository;
+
+    @Autowired
+    public UserRepositoryTest(DataSource dataSource) {
+        this.userRepository = new JdbcUserRepository(dataSource);
+    }
+
+    @Nested
+    @DisplayName("유저 정보를 가져올때,")
+    class findByIdTest {
+
+        @Test
+        @DisplayName("해당 아이디의 유저가 없다면 빈 객체를 반환한다.")
+        void notExistUser() {
+            // when
+            Optional<User> result = userRepository.findById(DEFAULT_USER_ID);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @Sql("classpath:sql/test/user-dml-h2.sql")
+        @DisplayName("해당 아이디의 유저가 존재한다면 User 객체를 반환한다.")
+        void ExistUser() {
+            // given
+            // 1개의 테스트 데이터 추가
+
+            // when
+            Optional<User> result = userRepository.findById(DEFAULT_USER_ID);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).isInstanceOf(User.class);
+            assertThat(result.get().getId()).isEqualTo(DEFAULT_USER_ID);
+        }
+    }
+}

--- a/be/src/test/java/com/ijava/todolist/user/service/UserServiceTest.java
+++ b/be/src/test/java/com/ijava/todolist/user/service/UserServiceTest.java
@@ -1,0 +1,74 @@
+package com.ijava.todolist.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.BDDMockito.given;
+
+import com.ijava.todolist.user.domain.User;
+import com.ijava.todolist.user.exception.UserNotFoundException;
+import com.ijava.todolist.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService 테스트")
+class UserServiceTest {
+
+    private static final Long DEFAULT_USER_ID = 1L;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Nested
+    @DisplayName("기본 회원 아이디를 조회할때,")
+    class findDefaultUserIdTest {
+
+        @Test
+        @DisplayName("기본 회원이 존재하면 예외가 발생하지 않고, 아이디를 반환한다.")
+        void defaultUserExist() {
+            // given
+            User defaultUser = new User(
+                1L,
+                "defaultUser",
+                LocalDateTime.parse("2022-04-05T19:12:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                LocalDateTime.parse("2022-04-05T19:12:11", DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            );
+            given(userRepository.findById(DEFAULT_USER_ID))
+                .willReturn(Optional.of(defaultUser));
+
+            // when
+            Long resultId = userService.findDefaultUserId();
+            Throwable thrown = catchThrowable(() -> userService.findDefaultUserId());
+
+            // then
+            assertThat(resultId).isEqualTo(DEFAULT_USER_ID);
+            assertThat(thrown).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("기본 회원이 존재하지 않으면 UserNotFoundException 예외가 발생한다.")
+        void defaultUserNotExist() {
+            // given
+            given(userRepository.findById(DEFAULT_USER_ID))
+                .willReturn(Optional.empty());
+
+            // when
+            Throwable thrown = catchThrowable(() -> userService.findDefaultUserId());
+
+            // then
+            assertThat(thrown).isInstanceOf(UserNotFoundException.class)
+                .hasMessageContaining("사용자를 찾을 수 없습니다.");
+        }
+    }
+}


### PR DESCRIPTION
- 활동 기록 입력 기능 추가
- 활동 기록 조회 기능 추가
- 'history' 테이블의 'action' 컬럼 범위 수정(char -> char(6))

### 📕 Issue Number

close #7

### 📙 작업 내역

- [x] 활동기록 기능 구현

### 📘 작업 유형

- [x] 신규 기능 추가

### 📝 PR 특이 사항

- `Util` 성 `HistoryResolver` 클래스를 구현하였습니다.
- 추가적으로 기본 유저 아이디를 반환하는 `getDefaultUserId()` 메소드를 `HistoryService` 클래스에 생성하였습니다.

<br/><br/>
