### PR TITLE
fix: 삭제된 카드는 개수를 세지 않도록 수정

### DIFF
--- a/be/src/main/java/com/ijava/todolist/card/repository/JdbcCardRepository.java
+++ b/be/src/main/java/com/ijava/todolist/card/repository/JdbcCardRepository.java
@@ -4,6 +4,7 @@ import com.ijava.todolist.card.domain.Card;
 import com.ijava.todolist.card.exception.CardNotSavedException;
 import com.ijava.todolist.common.domain.Deleted;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.relational.core.sql.Delete;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -157,11 +158,11 @@ public class JdbcCardRepository implements CardRepository {
 
     @Override
     public Optional<Integer> getCountOfCardsOnColumns(Long columnsId) {
-        String getCountSql = "SELECT count(*) FROM card WHERE columns_id = ?";
+        String getCountSql = "SELECT count(*) FROM card WHERE columns_id = ? AND deleted = ?";
 
         log.debug(getCountSql);
 
-        return Optional.ofNullable(jdbcTemplate.queryForObject(getCountSql, Integer.class, columnsId));
+        return Optional.ofNullable(jdbcTemplate.queryForObject(getCountSql, Integer.class, columnsId, Deleted.N));
     }
 
     private RowMapper<Card> cardRowMapper() {


### PR DESCRIPTION
### 📕 Issue Number

close #32 

### 📙 작업 내역

- [x] 삭제된 카드의 개수는 카운팅하지 않도록 수정

### 📘 작업 유형

- [x] 버그 수정
