### PR TITLE
docs: Swagger 를 통한 API 문서 자동화 적용 (#35)

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-ui:1.6.7'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'

--- a/be/src/main/java/com/ijava/todolist/card/controller/CardController.java
+++ b/be/src/main/java/com/ijava/todolist/card/controller/CardController.java
@@ -3,14 +3,22 @@ package com.ijava.todolist.card.controller;
 import com.ijava.todolist.card.controller.dto.*;
 import com.ijava.todolist.card.service.CardActionService;
 import com.ijava.todolist.card.service.CardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Tag(name = "cards", description = "카드 API")
 @RestController
 @RequiredArgsConstructor
 public class CardController {
@@ -18,6 +26,20 @@ public class CardController {
     private final CardService cardService;
     private final CardActionService cardActionService;
 
+    @Operation(summary = "카드 목록 조회",
+            description = "특정 컬럼에 속한 카드 목록을 조회합니다",
+            responses = {
+                @ApiResponse(responseCode = "200",
+                        description = "게시글 조회 성공",
+                        content = {
+                            @Content(
+                                    mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(implementation = CardResponse.class))
+                            )
+                        }
+                )
+            }
+    )
     @GetMapping("/cards")
     public List<CardResponse> cardList(@RequestParam(value="columnId") Long columnId) {
         return cardService.findCardList(columnId)
@@ -27,23 +49,73 @@ public class CardController {
                 .collect(Collectors.toUnmodifiableList());
     }
 
+    @Operation(summary = "카드 입력",
+            description = "새로운 카드를 추가합니다",
+            responses = {
+                    @ApiResponse(responseCode = "201",
+                            description = "카드 입력 성공",
+                            content = {
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = CardResponse.class)
+                                    )
+                            }
+                    )
+            }
+    )
     @PostMapping("/cards")
     @ResponseStatus(value = HttpStatus.CREATED)
     public CardResponse createCard(@RequestBody CardCreateRequest cardCreateRequest) {
         return cardActionService.add(cardCreateRequest);
     }
 
+    @Operation(summary = "카드 수정",
+            description = "카드를 수정합니다",
+            responses = {
+                    @ApiResponse(responseCode = "204",
+                            description = "카드 수정 성공"
+                    )
+            }
+    )
     @PutMapping("/cards/{id}")
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
     public void updateCard(@PathVariable("id") Long id, @RequestBody CardUpdateRequest updateRequest) {
         cardActionService.update(id, updateRequest);
     }
 
+    @Operation(summary = "카드 칼럼 이동",
+            description = "카드의 컬럼을 변경합니다",
+            responses = {
+                    @ApiResponse(responseCode = "200",
+                            description = "카드 칼럼 이동 성공",
+                            content = {
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = CardMovedResponse.class)
+                                    )
+                            }
+                    )
+            }
+    )
     @PatchMapping("/cards")
     public CardMovedResponse moveCard(@RequestBody CardMoveRequest cardMoveRequest) {
         return cardActionService.move(cardMoveRequest);
     }
 
+    @Operation(summary = "카드 삭제",
+            description = "카드를 삭제합니다",
+            responses = {
+                    @ApiResponse(responseCode = "200",
+                            description = "카드 삭제 성공",
+                            content = {
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema = @Schema(implementation = CardDeleteResponse.class)
+                                    )
+                            }
+                    )
+            }
+    )
     @DeleteMapping("/cards/{id}")
     public CardDeleteResponse deleteCard(@PathVariable("id") Long id) {
         return cardActionService.delete(id);

--- a/be/src/main/java/com/ijava/todolist/card/controller/dto/CardCreateRequest.java
+++ b/be/src/main/java/com/ijava/todolist/card/controller/dto/CardCreateRequest.java
@@ -1,13 +1,21 @@
 package com.ijava.todolist.card.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "카드 생성 요청")
 @Getter
 @NoArgsConstructor
 public class CardCreateRequest {
+
+    @Schema(description = "칼럼 아이디")
     private Long columnId;
+
+    @Schema(description = "제목")
     private String title;
+
+    @Schema(description = "내용")
     private String content;
 
     public CardCreateRequest(Long columnId, String title, String content) {

--- a/be/src/main/java/com/ijava/todolist/card/controller/dto/CardDeleteResponse.java
+++ b/be/src/main/java/com/ijava/todolist/card/controller/dto/CardDeleteResponse.java
@@ -1,11 +1,15 @@
 package com.ijava.todolist.card.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "삭제된 카드 정보")
 @Getter
 @NoArgsConstructor
 public class CardDeleteResponse {
+
+    @Schema(description = "삭제된 카드 아이디")
     private Long cardId;
 
     public CardDeleteResponse(Long cardId) {

--- a/be/src/main/java/com/ijava/todolist/card/controller/dto/CardMoveRequest.java
+++ b/be/src/main/java/com/ijava/todolist/card/controller/dto/CardMoveRequest.java
@@ -1,12 +1,18 @@
 package com.ijava.todolist.card.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "카드 이동 요청")
 @Getter
 @NoArgsConstructor
 public class CardMoveRequest {
+
+    @Schema(description = "카드 아이디")
     private Long cardId;
+
+    @Schema(description = "이동할 칼럼 아이디")
     private Long columnId;
 
     public CardMoveRequest(Long cardId, Long columnId) {

--- a/be/src/main/java/com/ijava/todolist/card/controller/dto/CardMovedResponse.java
+++ b/be/src/main/java/com/ijava/todolist/card/controller/dto/CardMovedResponse.java
@@ -1,13 +1,21 @@
 package com.ijava.todolist.card.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "카드 이동 정보")
 @Getter
 @NoArgsConstructor
 public class CardMovedResponse {
+
+    @Schema(description = "카드 아이디")
     private Long cardId;
+
+    @Schema(description = "변경 전 칼럼 아이디")
     private Long oldColumn;
+
+    @Schema(description = "변경 후 칼럼 아이디")
     private Long newColumn;
 
     public CardMovedResponse(Long cardId, Long oldColumn, Long newColumn) {

--- a/be/src/main/java/com/ijava/todolist/card/controller/dto/CardResponse.java
+++ b/be/src/main/java/com/ijava/todolist/card/controller/dto/CardResponse.java
@@ -2,21 +2,36 @@ package com.ijava.todolist.card.controller.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.ijava.todolist.card.domain.Card;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
-@ToString
+@Schema(description = "카드 정보")
 @Getter
 @NoArgsConstructor
 public class CardResponse {
+
+
+
+    @Schema(description = "카드 아이디")
     private Long cardId;
+
+    @Schema(description = "속한 칼럼 아이디")
     private Long columnId;
+
+    @Schema(description = "제목")
     private String title;
+
+    @Schema(description = "내용")
     private String content;
+
+    @Schema(description = "최초등록일", example = "2022-04-14T11:22:33")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdDate;
+
+    @Schema(description = "최종수정일", example = "2022-04-14T11:22:33")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime modifiedDate;
 

--- a/be/src/main/java/com/ijava/todolist/card/controller/dto/CardUpdateRequest.java
+++ b/be/src/main/java/com/ijava/todolist/card/controller/dto/CardUpdateRequest.java
@@ -1,12 +1,18 @@
 package com.ijava.todolist.card.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "카드 수정 요청")
 @Getter
 @NoArgsConstructor
 public class CardUpdateRequest {
+
+    @Schema(description = "수정된 제목")
     private String title;
+
+    @Schema(description = "수정된 내용")
     private String content;
 
     public CardUpdateRequest(String title, String content) {

--- a/be/src/main/java/com/ijava/todolist/column/controller/ColumnController.java
+++ b/be/src/main/java/com/ijava/todolist/column/controller/ColumnController.java
@@ -1,17 +1,26 @@
 package com.ijava.todolist.column.controller;
 
+import com.ijava.todolist.card.controller.dto.CardResponse;
 import com.ijava.todolist.card.service.CardService;
 import com.ijava.todolist.column.controller.dto.ColumnResponse;
 import com.ijava.todolist.column.domain.Column;
 import com.ijava.todolist.column.service.ColumnService;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "columns", description = "컬럼 API")
 @RequiredArgsConstructor
 @RestController
 public class ColumnController {
@@ -19,6 +28,20 @@ public class ColumnController {
     private final ColumnService columnService;
     private final CardService cardService;
 
+    @Operation(summary = "컬럼 목록 조회",
+            description = "컬럼 목록을 조회합니다",
+            responses = {
+                    @ApiResponse(responseCode = "200",
+                            description = "컬럼 조회 성공",
+                            content = {
+                                    @Content(
+                                            mediaType = "application/json",
+                                            array = @ArraySchema(schema = @Schema(implementation = ColumnResponse.class))
+                                    )
+                            }
+                    )
+            }
+    )
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/columns")
     public List<ColumnResponse> columnList() {

--- a/be/src/main/java/com/ijava/todolist/column/controller/dto/ColumnResponse.java
+++ b/be/src/main/java/com/ijava/todolist/column/controller/dto/ColumnResponse.java
@@ -3,15 +3,22 @@ package com.ijava.todolist.column.controller.dto;
 
 import com.ijava.todolist.card.service.CardService;
 import com.ijava.todolist.column.domain.Column;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
+@Schema(description = "컬럼 정보")
 @Getter
 @Setter
 public class ColumnResponse {
 
+    @Schema(description = "컬럼 아이디")
     private Long columnId;
+
+    @Schema(description = "컬럼 이름")
     private String name;
+
+    @Schema(description = "해당 컬럼에 속하는 카드 개수")
     private int cardCount;
 
     public static ColumnResponse from(Column column, CardService cardService) {

--- a/be/src/main/java/com/ijava/todolist/config/SwaggerConfig.java
+++ b/be/src/main/java/com/ijava/todolist/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package com.ijava.todolist.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI todoListOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Todo-list API")
+                        .description("Todo-list API Documentation")
+                        .version("1.0")
+                );
+
+    }
+
+}

--- a/be/src/main/java/com/ijava/todolist/history/controller/HistoryController.java
+++ b/be/src/main/java/com/ijava/todolist/history/controller/HistoryController.java
@@ -1,5 +1,6 @@
 package com.ijava.todolist.history.controller;
 
+import com.ijava.todolist.card.controller.dto.CardResponse;
 import com.ijava.todolist.history.Action;
 import com.ijava.todolist.history.controller.dto.HistoryResponse;
 import com.ijava.todolist.history.domain.History;
@@ -9,18 +10,39 @@ import com.ijava.todolist.history.util.HistoryResolver;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "history", description = "활동 기록 API")
 @RestController
 @RequiredArgsConstructor
 public class HistoryController {
 
     private final HistoryService historyService;
 
+    @Operation(summary = "활동 기록 조회",
+            description = "활동 기록 목록을 조회합니다",
+            responses = {
+                    @ApiResponse(responseCode = "200",
+                            description = "활동 기록 조회 성공",
+                            content = {
+                                    @Content(
+                                            mediaType = "application/json",
+                                            array = @ArraySchema(schema = @Schema(implementation = HistoryResponse.class))
+                                    )
+                            }
+                    )
+            }
+    )
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/history")
     public List<HistoryResponse> historyList() {

--- a/be/src/main/java/com/ijava/todolist/history/controller/dto/HistoryResponse.java
+++ b/be/src/main/java/com/ijava/todolist/history/controller/dto/HistoryResponse.java
@@ -1,26 +1,48 @@
 package com.ijava.todolist.history.controller.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.ijava.todolist.history.domain.History;
 import java.time.LocalDateTime;
 
 import com.ijava.todolist.history.repository.dto.JoinedHistory;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@Schema(description = "활동 기록 정보")
 @Getter
 @Setter
 @NoArgsConstructor
 public class HistoryResponse {
 
+    @Schema(description = "사용자 활동")
     private String action;
+
+    @Schema(description = "카드 아이디")
     private Long cardId;
+
+    @Schema(description = "카드 제목")
     private String cardTitle;
+
+    @Schema(description = "이전 컬럼 아이디")
     private Long oldColumn;
+
+    @Schema(description = "이전 컬럼 이름")
     private String oldColumnName;
+
+    @Schema(description = "이후 컬럼 아이디")
     private Long newColumn;
+
+    @Schema(description = "이후 컬럼 이름")
     private String newColumnName;
+
+    @Schema(description = "최초등록일", example = "2022-04-14T11:22:33", pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdDate;
+
+    @Schema(description = "최종수정일", example = "2022-04-14T11:22:33", pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime modifiedDate;
 
     public HistoryResponse(History history) {


### PR DESCRIPTION
### 📙 작업 내역

- docs: Swagger 를 통한 API 문서 자동화 적용
    - Swagger, Springdoc 의존성 추가
    - 각 Controller, DTO 에 문서화 어노테이션 추가
- docs: 불필요한 Swagger 설정 제거

### 📘 작업 유형

- 신규 기능 추가
- 문서 업데이트
